### PR TITLE
Fix filterDateFormat when provided with null or empty values.

### DIFF
--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -87,7 +87,7 @@ class TwigExtension extends AbstractExtension implements CoreAwareInterface
         $fmt = new \IntlDateFormatter($locale ?? $this->getCore()->getLocale(), \IntlDateFormatter::FULL, \IntlDateFormatter::FULL);
         $fmt->setPattern((string) $pattern);
 
-        if ($datetime instanceof \DateTime) {
+        if ($datetime instanceof \DateTimeInterface) {
             return $fmt->format($datetime);
         }
 

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -87,7 +87,7 @@ class TwigExtension extends AbstractExtension implements CoreAwareInterface
         $fmt = new \IntlDateFormatter($locale ?? $this->getCore()->getLocale(), \IntlDateFormatter::FULL, \IntlDateFormatter::FULL);
         $fmt->setPattern((string) $pattern);
 
-        if ($datetime instanceof \DateTimeInterface) {
+        if ($datetime instanceof \DateTime) {
             return $fmt->format($datetime);
         }
 
@@ -95,7 +95,15 @@ class TwigExtension extends AbstractExtension implements CoreAwareInterface
             return $fmt->format((int) $datetime);
         }
 
-        return $fmt->format(strtotime($datetime));
+        if(is_string($datetime)) {
+            $result = $fmt->format(strtotime($datetime));
+
+            if($result) {
+                return $result;
+            }
+        }
+
+        return "";
     }
 
     /**


### PR DESCRIPTION
The method filterDateFormat did not behave correctly when provided with empty values (whether it was null or just an empty string), it was crashing instead of returning something like an empty string. This PR addresses that, in the way that the function should not make a page crash if provided with empty values (and the default filter isn't even usable in that case because of crashing).